### PR TITLE
Update `astroid` to version `2.12.1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.9.0" %}
+{% set version = "2.12.1" %}
 
 package:
   name: astroid
@@ -6,12 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/astroid/astroid-{{ version }}.tar.gz
-  sha256: 5939cf55de24b92bda00345d4d0659d01b3c7dafb5055165c330bc7c568ba273
+  sha256: 6780c1e5581abe2af53417b51120faac23f332e0868e88a3a4f5e895d75ec5f9
 
 build:
   number: 0
-  # trigger: 1
-  skip: true  # [py<36]
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -20,12 +19,12 @@ requirements:
     - pip
     - pytest-runner
     - setuptools >=20.0
-    - wheel
+    - wheel !=0.37.1
   run:
     - python
-    - setuptools >=20.0
+    - setuptools !=62.6
     - lazy-object-proxy >=1.4.0
-    - wrapt >=1.11,<1.14
+    - wrapt >=1.11,<2
     - typed-ast >=1.4.0,<2.0  # [py<38]
     - typing-extensions >=3.10 # [py<310]
 
@@ -47,7 +46,7 @@ about:
   description: |
     Astroid provide a common base representation of python source code for
     projects such as pychecker, pyreverse, pylint.
-  doc_url: http://astroid.readthedocs.io/en/latest/?badge=latest
+  doc_url: https://pylint.pycqa.org/projects/astroid/en/latest/?badge=latest
   doc_source_url: https://github.com/PyCQA/astroid/blob/master/doc/index.rst
   dev_url: https://github.com/PyCQA/astroid
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,27 +18,31 @@ requirements:
     - python
     - pip
     - pytest-runner
-    - setuptools >=20.0
-    - wheel !=0.37.1
+    - setuptools
+    - wheel
   run:
     - python
-    - setuptools !=62.6
     - lazy-object-proxy >=1.4.0
     - wrapt >=1.11,<2
     - typed-ast >=1.4.0,<2.0  # [py<38]
     - typing-extensions >=3.10 # [py<310]
+  run_constrained:
+    - python >=3.7.2
 
 test:
   requires:
     - pip
   imports:
     - astroid
+    - astroid.brain
+    - astroid.interpreter
+    - astroid.nodes
     - astroid.modutils
   commands:
     - python -m pip check
 
 about:
-  home: https://www.astroid.org/
+  home: https://github.com/PyCQA/astroid
   license: LGPL-2.1-or-later
   license_family: LGPL
   license_file: LICENSE


### PR DESCRIPTION
`astroid` version `2.12.1`
1. - [x] Check the upstream
    https://github.com/PyCQA/astroid/tree/v2.12.1
2. - [x] Check the pinnings
  
  `requires-python = ">=3.7.2"`
  https://github.com/PyCQA/astroid/blob/v2.12.1/pyproject.toml#L33

  `wrapt>=1.11,<2`
  https://github.com/PyCQA/astroid/blob/v2.12.1/pyproject.toml#L36

  `"lazy_object_proxy>=1.4.0"`
  https://github.com/PyCQA/astroid/blob/v2.12.1/pyproject.toml#L35

  `typed-ast>=1.4.0,<2.0`
  https://github.com/PyCQA/astroid/blob/v2.12.1/pyproject.toml#L37

  `typing-extensions>=3.10`
  https://github.com/PyCQA/astroid/blob/v2.12.1/pyproject.toml#L38

  `"setuptools~=62.6"` 
  `"wheel~=0.37.1"`
  https://github.com/PyCQA/astroid/blob/v2.12.1/pyproject.toml#L2


3. - [x] Check the changelogs

   https://github.com/PyCQA/astroid/blob/v2.12.1/ChangeLog

    What's New in astroid 2.12.1?
=============================
Release date: 2022-07-10

* Fix a crash when inferring old-style string formatting (``%``) using tuples.

* Fix a crash when ``None`` (or a value inferred as ``None``) participates in a
  ``**`` expression.

* Fix a crash involving properties within ``if`` blocks.


What's New in astroid 2.12.0?
=============================
Release date: 2022-07-09

* Fix signal has no ``connect`` member for PySide2 5.15.2+ and PySide6

  Closes #4040, #5378

* ``astroid`` now requires Python 3.7.2 to run.

* Avoid setting a Call as a base for classes created using ``six.with_metaclass()``.

  Refs PyCQA/pylint#5935

* Fix detection of builtins on ``PyPy`` 3.9.

* Fix ``re`` brain on Python ``3.11``. The flags now come from ``re._compile``.

* Build ``nodes.Module`` for frozen modules which have location information in their
  ``ModuleSpec``.

  Closes #1512

  `collections_abc` will be frozen in 3.11
  https://github.com/PyCQA/astroid/issues/1512

* The ``astroid.mixins`` module has been deprecated and marked for removal in 3.0.0.

  Closes #1633
  
  Move `mixins.py` to `astroid.nodes._base_nodes`
  https://github.com/PyCQA/astroid/issues/1633

* Capture and log messages emitted by C extensions when importing them.
  This prevents contaminating programmatic output, e.g. pylint's JSON reporter.

  Closes PyCQA/pylint#3518

* Calls to ``str.format`` are now correctly inferred.

  Closes #104, Closes #1611

  Infer calls to str.format() on names #
  https://github.com/PyCQA/astroid/issues/1611

* ``__new__`` and ``__init__`` have been added to the ``ObjectModel`` and are now
  inferred as ``BoundMethods``.

* Old style string formatting (using ``%`` operators) is now correctly inferred.

  Closes #151

  Infer string interpolation with %
  https://github.com/PyCQA/astroid/issues/151

* Adds missing enums from ``ssl`` module.

  Closes PyCQA/pylint#3691

* Remove dependency on ``pkg_resources`` from ``setuptools``.

  Closes #1103

  Remove dependency to `setuptools` and `distutil`
  https://github.com/PyCQA/astroid/issues/1103

* Allowed ``AstroidManager.clear_cache`` to reload necessary brain plugins.

* Fixed incorrect inferences after rebuilding the builtins module, e.g. by calling
  ``AstroidManager.clear_cache``.

  Closes #1559

  Pollution test cases 
  https://github.com/PyCQA/astroid/issues/1559

* On Python versions >= 3.9, ``astroid`` now understands subscripting
  builtin classes such as ``enumerate`` or ``staticmethod``.

* Fixed inference of ``Enums`` when they are imported under an alias.

  Closes PyCQA/pylint#5776

* Rename ``ModuleSpec`` -> ``module_type`` constructor parameter to match attribute
  name and improve typing. Use ``type`` instead.

* ``ObjectModel`` and ``ClassModel`` now know about their ``__new__`` and ``__call__`` attributes.

* Fixed pylint ``not-callable`` false positive with nested-tuple assignment in a for-loop.

  Refs PyCQA/pylint#5113

* Instances of builtins created with ``__new__(cls, value)`` are now inferred.

* Infer the return value of the ``.copy()`` method on ``dict``, ``list``, ``set``,
  and ``frozenset``.

  Closes #1403

  dict.copy() result is not inferred as dict
  https://github.com/PyCQA/astroid/issues/1403

* Fixed inference of elements of living container objects such as tuples and sets in the
  ``sys`` and ``ssl`` modules.

* Add ``pathlib`` brain to handle ``pathlib.PurePath.parents`` inference.

  Closes PyCQA/pylint#5783

* Avoid inferring the results of ``**`` operations involving values greater than ``1e5``
  to avoid expensive computation.

  Closes PyCQA/pylint#6745

* Fix test for Python ``3.11``. In some instances ``err.__traceback__`` will
  be uninferable now.

* Add brain for numpy core module ``einsumfunc``.

  Closes PyCQA/pylint#5821

* Infer the ``DictUnpack`` value for ``Dict.getitem`` calls.

  Closes #1195

  getitem does not infer the actual unpacked value
  https://github.com/PyCQA/astroid/issues/1195

* Fix a crash involving properties within ``try ... except`` blocks.

  Closes PyCQA/pylint#6592

* Prevent creating ``Instance`` objects that proxy other ``Instance``s when there is
  ambiguity (or user error) in calling ``__new__(cls)``.

  Refs PyCQA/pylint#7109

What's New in astroid 2.11.7?
=============================
Release date: 2022-07-09

* Added support for ``usedforsecurity`` keyword to ``hashlib`` constructors.

  Closes PyCQA/pylint#6017

* Updated the stdlib brain for ``subprocess.Popen`` to accommodate Python 3.9+.

  Closes PyCQA/pylint#7092

What's New in astroid 2.11.6?
=============================
Release date: 2022-06-13

* The Qt brain now correctly treats calling ``.disconnect()`` (with no
  arguments) on a slot as valid.

* The argparse brain no longer incorrectly adds ``"Namespace"`` to the locals
  of functions that return an ``argparse.Namespace`` object.

  Refs PyCQA/pylint#6895

What's New in astroid 2.11.5?
=============================
Release date: 2022-05-09

* Fix crash while obtaining ``object_type()`` of an ``Unknown`` node.

  Refs PyCQA/pylint#6539

* Fix a bug where in attempting to handle the patching of ``distutils`` by ``virtualenv``,
  library submodules called ``distutils`` (e.g. ``numpy.distutils``) were included also.

  Refs PyCQA/pylint#6497

What's New in astroid 2.11.4?
=============================
Release date: 2022-05-02

* Fix ``col_offset`` attribute for nodes involving ``with`` on ``PyPy``.

* Fixed a crash involving two starred expressions: one inside a comprehension,
  both inside a call.

  Refs PyCQA/pylint#6372

* Made ``FunctionDef.implicit_parameters`` return 1 for methods by making
  ``FunctionDef.is_bound`` return ``True``, as it does for class methods.

  Closes PyCQA/pylint#6464

* Fixed a crash when ``_filter_stmts`` encounters an ``EmptyNode``.

  Closes PyCQA/pylint#6438


What's New in astroid 2.11.3?
=============================
Release date: 2022-04-19

* Fixed an error in the Qt brain when building ``instance_attrs``.

  Closes PyCQA/pylint#6221

* Fixed a crash in the ``gi`` brain.

  Closes PyCQA/pylint#6371


What's New in astroid 2.11.2?
=============================
Release date: 2022-03-26

* Avoided adding the name of a parent namedtuple to its child's locals.

  Refs PyCQA/pylint#5982


What's New in astroid 2.11.1?
=============================
Release date: 2022-03-22

* Promoted ``getattr()`` from ``astroid.scoped_nodes.FunctionDef`` to its parent
  ``astroid.scoped_nodes.Lambda``.

* Fixed crash on direct inference via ``nodes.FunctionDef._infer``.

  Closes #817

IndexError in FunctionDef._infer()
https://github.com/PyCQA/astroid/issues/817

What's New in astroid 2.11.0?
=============================
Release date: 2022-03-12

* Add new (optional) ``doc_node`` attribute to ``nodes.Module``, ``nodes.ClassDef``,
  and ``nodes.FunctionDef``.

* Accessing the ``doc`` attribute of ``nodes.Module``, ``nodes.ClassDef``, and
  ``nodes.FunctionDef`` has been deprecated in favour of the ``doc_node`` attribute.
  Note: ``doc_node`` is an (optional) ``nodes.Const`` whereas ``doc`` was an (optional) ``str``.

* Passing the ``doc`` argument to the ``__init__`` of ``nodes.Module``, ``nodes.ClassDef``,
  and ``nodes.FunctionDef`` has been deprecated in favour of the ``postinit`` ``doc_node`` attribute.
  Note: ``doc_node`` is an (optional) ``nodes.Const`` whereas ``doc`` was an (optional) ``str``.

* Replace custom ``cachedproperty`` with ``functools.cached_property`` and deprecate it
  for Python 3.8+.

  Closes #1410
  
  Replace `cachedproperty` with `functools.cached_property` (>= 3.8)
  https://github.com/PyCQA/astroid/issues/1410

* Set ``end_lineno`` and ``end_col_offset`` attributes to ``None`` for all nodes
  with PyPy 3.8. PyPy 3.8 assigns these attributes inconsistently which could lead
  to unexpected errors. Overwriting them with ``None`` will cause a fallback
  to the already supported way of PyPy 3.7.

* Add missing ``shape`` parameter to numpy ``zeros_like``, ``ones_like``,
  and ``full_like`` methods.

  Closes PyCQA/pylint#5871

* Only pin ``wrapt`` on the major version.


What's New in astroid 2.10.0?
=============================
Release date: 2022-02-27


* Fixed inference of ``self`` in binary operations in which ``self``
  is part of a list or tuple.

  Closes PyCQA/pylint#4826

* Fixed builtin inference on `property` calls not calling the `postinit` of the new node, which
  resulted in instance arguments missing on these nodes.

* Fixed a crash on ``Super.getattr`` when the attribute was previously uninferable due to a cache
  limit size. This limit can be hit when the inheritance pattern of a class (and therefore of the
  ``__init__`` attribute) is very large.

  Closes PyCQA/pylint#5679

* Inlcude names of keyword-only arguments in ``astroid.scoped_nodes.Lambda.argnames``.

  Closes PyCQA/pylint#5771

* Fixed a crash inferring on a ``NewType`` named with an f-string.

  Closes PyCQA/pylint#5770

* Add support for [attrs v21.3.0](https://github.com/python-attrs/attrs/releases/tag/21.3.0) which
  added a new `attrs` module alongside the existing `attr`.

  Closes #1330

  `brain_attrs.py` does not support attrs v21.3.0+
  https://github.com/PyCQA/astroid/issues/1330

* Use the ``end_lineno`` attribute for the ``NodeNG.tolineno`` property
  when it is available.

  Closes #1350

  Decorator.toline is off by 1 
  https://github.com/PyCQA/astroid/issues/1350

* Add ``is_dataclass`` attribute to ``ClassDef`` nodes.

* Use ``sysconfig`` instead of ``distutils`` to determine the location of
  python stdlib files and packages.

  Related pull requests: #1322, #1323, #1324
  Closes #1282
  Ref #1103

  Change site packages look up to use sysconfig instead of distutils
  https://github.com/PyCQA/astroid/pull/1322

  Use `sysconfig.get_path` instead of `distutils` to find `stdlib` 
  https://github.com/PyCQA/astroid/pull/1323

  Use `sysconfig` to determine `stdlib` paths for `PyPy`
  https://github.com/PyCQA/astroid/pull/1324

  Python 3.10 deprecation warnings due to `distutils` import 
  https://github.com/PyCQA/astroid/issues/1282

  Remove dependency to `setuptools` and `distutil`
  https://github.com/PyCQA/astroid/issues/1103

* Fixed crash with recursion error for inference of class attributes that referenced
  the class itself.

  Closes PyCQA/pylint#5408

* Fixed crash when trying to infer ``items()`` on the ``__dict__``
  attribute of an imported module.

  Closes #1085

  AttributeInferenceError: Could not find original name for items in `Import` 
  https://github.com/PyCQA/astroid/issues/1085

* Add optional ``NodeNG.position`` attribute.
  Used for block nodes to highlight position of keyword(s) and name
  in cases where the AST doesn't provide good enough positional information.
  E.g. ``nodes.ClassDef``, ``nodes.FunctionDef``.

* Fix ``ClassDef.fromlineno``. For Python < 3.8 the ``lineno`` attribute includes decorators.
  ``fromlineno`` should return the line of the ``class`` statement itself.

* Performance improvements. Only run expensive decorator functions when
  non-default Deprecation warnings are enabled, eg. during a Pytest run.

  Closes #1383

  Fix performance issue with `inspect` calls in deprecation warnings decorators
  https://github.com/PyCQA/astroid/issues/1383


What's New in astroid 2.9.3?
============================
Release date: 2022-01-09

* Fixed regression where packages without a ``__init__.py`` file were
  not recognized or imported correctly.

  Closes #1327

  astroid 2.9.1 breaks pylint with missing __init__.py: F0010: error while code parsing: Unable to load file __init__.py 
  https://github.com/PyCQA/astroid/issues/1327

What's New in astroid 2.9.2?
============================
Release date: 2022-01-04

* Fixed regression in ``astroid.scoped_nodes`` where ``_is_metaclass``
  was not accessible anymore.

Closes #1325

Fix import astroid.scoped_nodes
https://github.com/PyCQA/astroid/pull/1325

What's New in astroid 2.9.1?
============================
Release date: 2021-12-31

* ``NodeNG.frame()`` and ``NodeNG.statement()`` will start raising ``ParentMissingError``
  instead of ``AttributeError`` in astroid 3.0. This behaviour can already be triggered
  by passing ``future=True`` to a ``frame()`` or ``statement()`` call.

* Prefer the module loader get_source() method in AstroidBuilder's
  module_build() when possible to avoid assumptions about source
  code being available on a filesystem.  Otherwise the source cannot
  be found and application behavior changes when running within an
  embedded hermetic interpreter environment (pyoxidizer, etc.).

* Require Python 3.6.2 to use astroid.

* Removed custom ``distutils`` handling for resolving paths to submodules.

  Ref #1321
  
  Remove `distutils` path patching 
  https://github.com/PyCQA/astroid/pull/1321

* Restore custom ``distutils`` handling for resolving paths to submodules.

  Closes PyCQA/pylint#5645

* Fix ``deque.insert()`` signature in ``collections`` brain.

  Closes #1260

  deque.insert() has reversed args
  https://github.com/PyCQA/astroid/issues/1260

* Fix ``Module`` nodes not having a ``col_offset``, ``end_lineno``, and ``end_col_offset``
  attributes.

* Fix typing and update explanation for ``Arguments.args`` being ``None``.

* Fix crash if a variable named ``type`` is accessed with an index operator (``[]``)
  in a generator expression.

  Closes PyCQA/pylint#5461

* Enable inference of dataclass import from marshmallow_dataclass.
  This allows the dataclasses brain to recognize dataclasses annotated by marshmallow_dataclass.

* Resolve symlinks in the import path
  Fixes inference error when the import path includes symlinks (e.g. Python
  installed on macOS via Homebrew).

  Closes #823
  Closes PyCQA/pylint#3499
  Closes PyCQA/pylint#4302
  Closes PyCQA/pylint#4798
  Closes PyCQA/pylint#5081

What's New in astroid 2.9.0?
============================
Release date: 2021-11-21

* Add ``end_lineno`` and ``end_col_offset`` attributes to astroid nodes.

* Always treat ``__class_getitem__`` as a classmethod.

* Add missing ``as_string`` visitor method for ``Unknown`` node.

  Closes #1264

  'AsStringVisitor' object has no attribute 'visit_unknown' 
  https://github.com/PyCQA/astroid/issues/1264

4. - [x] Additional research
    https://github.com/conda-forge/astroid-feedstock/issues

    There are currently no open issues mentioned at the time of the review.

5. - [x] Verify the `dev_url`
    https://github.com/PyCQA/astroid
6. - [x] Verify the `doc_url`
    
    There seems to be a redirect to the following location

    https://pylint.pycqa.org/projects/astroid/en/latest/?badge=latest

7. - [x] License is `spdx` compliant
    LGPL-2.1-or-later
8. - [x] License family is present
    LGPL
9. - [x] Verify that the `build_number` is correct
10. - [x] Verify if the package needs `setuptools`
    setuptools
setuptools
11. - [x] Verify if the package needs `wheel`
    wheel
12. - [x] `pip` in the test section
    python
13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture specific` or `Noarch`
15. - [x] Private variables are not mentioned on the recipe For example: (_private_variable)
 
Results:
- 
 
 
Based on the research findings and the results we can conclude
that it is safe to update `astroid` to version `2.12.1`
