### PR TITLE
Update `Astroid` to Version `2.12.2`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.9.0" %}
+{% set version = "2.12.1" %}
 
 package:
   name: astroid
@@ -6,12 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/astroid/astroid-{{ version }}.tar.gz
-  sha256: 5939cf55de24b92bda00345d4d0659d01b3c7dafb5055165c330bc7c568ba273
+  sha256: 6780c1e5581abe2af53417b51120faac23f332e0868e88a3a4f5e895d75ec5f9
 
 build:
   number: 0
-  # trigger: 1
-  skip: true  # [py<36]
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -20,12 +19,12 @@ requirements:
     - pip
     - pytest-runner
     - setuptools >=20.0
-    - wheel
+    - wheel !=0.37.1
   run:
     - python
-    - setuptools >=20.0
+    - setuptools !=62.6
     - lazy-object-proxy >=1.4.0
-    - wrapt >=1.11,<1.14
+    - wrapt >=1.11,<2
     - typed-ast >=1.4.0,<2.0  # [py<38]
     - typing-extensions >=3.10 # [py<310]
 
@@ -47,7 +46,7 @@ about:
   description: |
     Astroid provide a common base representation of python source code for
     projects such as pychecker, pyreverse, pylint.
-  doc_url: http://astroid.readthedocs.io/en/latest/?badge=latest
+  doc_url: https://pylint.pycqa.org/projects/astroid/en/latest/?badge=latest
   doc_source_url: https://github.com/PyCQA/astroid/blob/master/doc/index.rst
   dev_url: https://github.com/PyCQA/astroid
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,11 +18,13 @@ requirements:
     - python
     - pip
     - pytest-runner
-    - setuptools !=62.6
-    - wheel !=0.37.1
+    # the setuptools version needs to be compatible with version 62
+    - setuptools >=62.6,<63.0.0
+    # the wheel version needs to be compatible with version 0.37
+    - wheel >=0.37.1,<0.38.0
   run:
     - python
-    - setuptools !=62.6
+    - setuptools >=62.6,<63.0.0
     - lazy-object-proxy >=1.4.0
     - wrapt >=1.11,<2
     - typed-ast >=1.4.0,<2.0  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.12.1" %}
+{% set version = "2.12.2" %}
 
 package:
   name: astroid
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/astroid/astroid-{{ version }}.tar.gz
-  sha256: 6780c1e5581abe2af53417b51120faac23f332e0868e88a3a4f5e895d75ec5f9
+  sha256: 4675ef501edbbb143b3d9bb4c81d5f6338f08f960beed2ce41a03dc4cd20d777
 
 build:
   number: 0
@@ -18,7 +18,7 @@ requirements:
     - python
     - pip
     - pytest-runner
-    - setuptools >=20.0
+    - setuptools !=62.6
     - wheel !=0.37.1
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,13 +18,10 @@ requirements:
     - python
     - pip
     - pytest-runner
-    # the setuptools version needs to be compatible with version 62
-    - setuptools >=62.6,<63.0.0
-    # the wheel version needs to be compatible with version 0.37
-    - wheel >=0.37.1,<0.38.0
+    - setuptools
+    - wheel
   run:
     - python
-    - setuptools >=62.6,<63.0.0
     - lazy-object-proxy >=1.4.0
     - wrapt >=1.11,<2
     - typed-ast >=1.4.0,<2.0  # [py<38]
@@ -35,12 +32,15 @@ test:
     - pip
   imports:
     - astroid
+    - astroid.brain
+    - astroid.interpreter
+    - astroid.nodes
     - astroid.modutils
   commands:
     - python -m pip check
 
 about:
-  home: https://www.astroid.org/
+  home: https://github.com/PyCQA/astroid
   license: LGPL-2.1-or-later
   license_family: LGPL
   license_file: LICENSE


### PR DESCRIPTION

`astroid` version `2.12.1`
1. - [x] Check the upstream
    https://github.com/PyCQA/astroid/tree/v2.12.1
2. - [x] Check the pinnings

`setuptools~=62.6`
`wheel~=0.37.1`
https://github.com/PyCQA/astroid/blob/v2.12.1/pyproject.toml#L2

`requires-python = ">=3.7.2"`
https://github.com/PyCQA/astroid/blob/v2.12.1/pyproject.toml#L33

3. - [x] Check the changelogs

    https://github.com/PyCQA/astroid/blob/v2.12.2/ChangeLog


    What's New in astroid 2.12.2?
=============================
Release date: 2022-07-12

* Fixed crash in modulo operations for divisions by zero.

  Closes #1700

  `Crash in modulo expression`
  https://github.com/PyCQA/astroid/issues/1700

* Fixed crash with recursion limits during inference.

  Closes #1646

  Infinite loop when inferring `from token import *`
  https://github.com/PyCQA/astroid/issues/1646

What's New in astroid 2.12.1?
=============================
Release date: 2022-07-10

* Fix a crash when inferring old-style string formatting (``%``) using tuples.

* Fix a crash when ``None`` (or a value inferred as ``None``) participates in a
  ``**`` expression.

* Fix a crash involving properties within ``if`` blocks.


4. - [x] Additional research
    https://github.com/conda-forge/astroid-feedstock/issues

    There are currently no open issues mentioned in the upstream.

5. - [x] Verify the `dev_url`
    https://github.com/PyCQA/astroid
6. - [x] Verify the `doc_url`

    https://pylint.pycqa.org/projects/astroid/en/latest/?badge=latest

7. - [x] License is `spdx` compliant
    LGPL-2.1-or-later
8. - [x] License family is present
    LGPL
9. - [x] Verify that the `build_number` is correct
10. - [x] Verify if the package needs `setuptools`
setuptools
11. - [x] Verify if the package needs `wheel`
12. - [x] `pip` in the test section
    python
13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture specific` or `Noarch`
15. - [x] Private variables are not mentioned on the recipe For example: (_private_variable)
 
Results:
- 
 
Based on the research findings and the results we can conclude
that it is safe to update `astroid` to version `2.12.1`

